### PR TITLE
feat: add eslint support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,26 @@
+# ignore code-generated contents
+migrations/*
+models/*
+# patches/*
+resolvers/*
+schemas/*
+# validations/*
+
+# un-ignore static migrations
+!migrations/default-sql
+migrations/default-sql/*
+
+# un-ignore static models
+!models/sql
+models/sql/*
+!models/index.js
+
+# un-ignore static models/adapters
+!models/adapters
+models/adapters/*
+!models/adapters/index.js
+
+# un-ignore all role, user, and role_to_user static files
+!**/*role_to_user.js
+!**/*role.js
+!**/*user.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,21 @@
+{
+  "root": true,
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "parser": "babel-eslint",
+  "rules": {
+
+    "indent": [ "warn", 2 ],
+
+    "linebreak-style": [ "error", "unix" ],
+
+    "no-unused-vars": [ "warn", { "args": "none" }],
+
+    "quotes": [ "warn", "single" ],
+
+    "semi": [ "error", "always" ]
+
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Schema as string",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint .",
     "start": "node server.js",
     "test": "mocha test/test.js --exit"
   },
@@ -49,8 +50,10 @@
     "xlsx": "^0.16.1"
   },
   "devDependencies": {
-    "mocha": "^7.1.2",
     "axios": "^0.19.2",
-    "form-data": "^3.0.0"
+    "babel-eslint": "^10.1.0",
+    "eslint": "^7.8.1",
+    "form-data": "^3.0.0",
+    "mocha": "^7.1.2"
   }
 }


### PR DESCRIPTION
## Issue

Related to `graphql-server-model-codegen` [#150](https://github.com/Zendro-dev/graphql-server-model-codegen/issues/150).

## Description

Added support for [ESLint](https://eslint.org/docs/rules/).

## Implementation

The `eslintrc` config extends `eslint:recommended`, with a few additions / modifications:

- The `parser` is set to use [`babel-eslint`](https://github.com/babel/babel-eslint).
- Standard rules for `indent`, `linebreak-style`, `quotes`, and `semi` have been set.
- Rule `no-unused-vars` has been set to `warn` for everything but function `args`.
- Code-generated folders are ignored using `.eslintignore` rules, except for the few files within that are provided statically.

## Blocks

None.

## Notes

- Using `babel-eslint` allows us to use features already supported by NodeJS `latest` (e.g. `static-class-props`). When Babel v8 is released this module will be deprecated in favor of [`@babel/eslint-parser`](https://github.com/babel/babel/tree/master/eslint/babel-eslint-parser). The migration will likely require a few additional configuration changes.