### PR TITLE
fix: metaquery return empty errors array as default

### DIFF
--- a/utils/helper.js
+++ b/utils/helper.js
@@ -1784,7 +1784,7 @@ module.exports.vueTable = function(req, model, strAttributes) {
     //prepare:
     compositeResponses = {
       data:   data.length === 1 ? data[0] : data,
-      errors: errors.length > 0 ? errors : undefined,
+      errors: errors
     }
     return compositeResponses;
   }


### PR DESCRIPTION
## Isssue

closes #59 

## Description

This PR fixes metaquery integration test 18. If a response of a metaquery does not contain any errors the empty errors array should be returned together with the data.