### PR TITLE
feat: mandatory environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ _NOTE: Databases should be already configured locally in `config/data_models_sto
 * `MAIL_PASSWORD` - Sender email account password.
 
 ### Optional (with sensible defaults)
-* `ERROR_LOG` - Debug logs verbosity. Can be either "verbose" or "compact".
-* `EXPORT_TIME_OUT` - Maximum amount of time before the server throws a timeout error when exporting data.
-* `LIMIT_RECORDS` - Maximum number of records that each request can return, default value is 10000.
+* `ERROR_LOG` - Debug logs verbosity. Can be either "verbose" or "compact". Default value is `compact`.
+* `EXPORT_TIME_OUT` - Maximum amount of time in milliseconds before the server throws a timeout error when exporting data. Default is `3600`.
+* `LIMIT_RECORDS` - Maximum number of records that each request can return, default value is `10000`.
 * `PORT` - The port where the app is listening, default value is `3000`
-* `POST_REQUEST_MAX_BODY_SIZE`
-* `MAX_TIME_OUT` - Maximum number of milliseconds that a zendro server will wait to connect with another zendro server.
-* `REQUIRE_SIGN_IN` - Boolean to toggle the required sign in to the graphql server
-* `SALT_ROUNDS`
+* `POST_REQUEST_MAX_BODY_SIZE` - Maximum size of the GraphQL request in MB. Default is `1mb`.
+* `MAX_TIME_OUT` - Maximum number of milliseconds that a zendro server will wait to connect with another zendro server. Default value is `2000`.
+* `REQUIRE_SIGN_IN` - Boolean to toggle the required sign in to the graphql server. Default is `true`.
+* `SALT_ROUNDS` - Number of salt rounds when hashing a new password. Default is `10`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,29 @@ The script ```$ migrateDbAndStartServer.sh``` will create the tables specified i
 _NOTE: Databases should be already configured locally in `config/data_models_storage_config.json`_.
 
 
-### Environment Variables
+## Environment Variables
 
-* `PORT` - The port where the app is listening, default value is `3000`
-* `ALLOW_ORIGIN` - In development mode we need to specify the header `Access-Control-Allow-Origin` so the SPA application can communicate with the server, default value is `http://localhost:8080`.
+### Mandatory
+* `ALLOW_ORIGIN` - Sets the `Access-Control-Allow-Origin` header to the specified value.
+* `JWT_SECRET` - The secret string used to sign authorization tokens.
+
+### Optional (without defaults)
+* `MAIL_SERVICE` - For bulk add operations, the email service to use for sending progress reports.
+* `MAIL_HOST` - Email service host (usually SMTP config).
+* `MAIL_ACCOUNT` - Sender email account address.
+* `MAIL_PASSWORD` - Sender email account password.
+
+### Optional (with sensible defaults)
+* `ERROR_LOG` - Debug logs verbosity. Can be either "verbose" or "compact".
+* `EXPORT_TIME_OUT` - Maximum amount of time before the server throws a timeout error when exporting data.
 * `LIMIT_RECORDS` - Maximum number of records that each request can return, default value is 10000.
+* `PORT` - The port where the app is listening, default value is `3000`
+* `POST_REQUEST_MAX_BODY_SIZE`
 * `MAX_TIME_OUT` - Maximum number of milliseconds that a zendro server will wait to connect with another zendro server.
 * `REQUIRE_SIGN_IN` - Boolean to toggle the required sign in to the graphql server
+* `SALT_ROUNDS`
+
+
 
 ## Examples
 

--- a/config/globals.js
+++ b/config/globals.js
@@ -1,18 +1,71 @@
 require('dotenv').config();
 
+/**
+ * Mandatory variables
+ */
+const ALLOW_ORIGIN = process.env.ALLOW_ORIGIN,
+const JWT_SECRET = process.env.JWT_SECRET,
+
+if (!ALLOW_ORIGIN || !JWT_SECRET) {
+  throw new Error('Some mandatory environment variables have not been set\n', {
+    ALLOW_ORIGIN,
+    JWT_SECRET,
+  })
+}
+
+/**
+ * Optional variables with no defaults
+ */
+
+const MAIL_ACCOUNT = process.env.MAIL_ACCOUNT;
+const MAIL_HOST = process.env.MAIL_HOST;
+const MAIL_PASSWORD = process.env.MAIL_PASSWORD;
+const MAIL_SERVICE = process.env.MAIL_SERVICE;
+
+if (!MAIL_ACCOUNT || !MAIL_HOST || !MAIL_PASSWORD || !MAIL_SERVICE) {
+  console.log('WARNING: BulkAdd email service has not been properly configured', {
+    MAIL_ACCOUNT,
+    MAIL_HOST,
+    MAIL_PASSWORD,
+    MAIL_SERVICE,
+  })
+}
+
+/**
+ * Optional variables with sensible defaults
+ */
+
+// Listening port
+const PORT = process.env.PORT || 3000;
+
+// Logging
+const ERROR_LOG = process.env.ERROR_LOG || 'compact';
+
+// Request Limits
+const LIMIT_RECORDS = process.env.LIMIT_RECORDS || 10000;
+const POST_REQUEST_MAX_BODY_SIZE = process.env.POST_REQUEST_MAX_BODY_SIZE || '1mb';
+
+// Security
+const REQUIRE_SIGN_IN = process.env.REQUIRE_SIGN_IN === "false" ? false : true;
+const SALT_ROUNDS = process.env.SALT_ROUNDS || 10;
+
+// Timeouts
+const MAX_TIME_OUT = process.env.MAX_TIME_OUT || 2000;
+const EXPORT_TIME_OUT = process.env.EXPORT_TIME_OUT || 3600
+
 module.exports = {
-  LIMIT_RECORDS : process.env.LIMIT_RECORDS || 10000,
-  PORT : process.env.PORT || 3000,
-  ALLOW_ORIGIN: process.env.ALLOW_ORIGIN || "http://localhost:8080",
-  JWT_SECRET: process.env.JWT_SECRET,
-  SALT_ROUNDS: process.env.SALT_ROUNDS || 10,
-  REQUIRE_SIGN_IN: process.env.REQUIRE_SIGN_IN === "false" ? false : true,
-  MAX_TIME_OUT: process.env.MAX_TIME_OUT || 2000,
-  POST_REQUEST_MAX_BODY_SIZE: process.env.POST_REQUEST_MAX_BODY_SIZE || '1mb',
-  ERROR_LOG: process.env.ERROR_LOG || 'compact',
-  MAIL_SERVICE: process.env.MAIL_SERVICE || "gmail",
-  MAIL_HOST: process.env.MAIL_HOST || "smtp.gmail.com",
-  MAIL_ACCOUNT: process.env.MAIL_ACCOUNT || "sci.db.service@gmail.com",
-  MAIL_PASSWORD: process.env.MAIL_PASSWORD || "SciDbServiceQAZ",
-  EXPORT_TIME_OUT: process.env.EXPORT_TIME_OUT || 3600
+  LIMIT_RECORDS,
+  PORT,
+  ALLOW_ORIGIN,
+  JWT_SECRET,
+  SALT_ROUNDS,
+  REQUIRE_SIGN_IN,
+  MAX_TIME_OUT,
+  POST_REQUEST_MAX_BODY_SIZE,
+  ERROR_LOG,
+  MAIL_SERVICE,
+  MAIL_HOST,
+  MAIL_ACCOUNT,
+  MAIL_PASSWORD,
+  EXPORT_TIME_OUT,
 }

--- a/config/globals.js
+++ b/config/globals.js
@@ -23,7 +23,7 @@ const MAIL_PASSWORD = process.env.MAIL_PASSWORD;
 const MAIL_SERVICE = process.env.MAIL_SERVICE;
 
 if (!MAIL_ACCOUNT || !MAIL_HOST || !MAIL_PASSWORD || !MAIL_SERVICE) {
-  console.log('WARNING: BulkAdd email service has not been properly configured', {
+  console.warn('WARNING: BulkAdd email service has not been properly configured', {
     MAIL_ACCOUNT,
     MAIL_HOST,
     MAIL_PASSWORD,

--- a/config/globals.js
+++ b/config/globals.js
@@ -3,8 +3,8 @@ require('dotenv').config();
 /**
  * Mandatory variables
  */
-const ALLOW_ORIGIN = process.env.ALLOW_ORIGIN,
-const JWT_SECRET = process.env.JWT_SECRET,
+const ALLOW_ORIGIN = process.env.ALLOW_ORIGIN;
+const JWT_SECRET = process.env.JWT_SECRET;
 
 if (!ALLOW_ORIGIN || !JWT_SECRET) {
   throw new Error('Some mandatory environment variables have not been set\n', {
@@ -53,7 +53,7 @@ const SALT_ROUNDS = process.env.SALT_ROUNDS || 10;
 const MAX_TIME_OUT = process.env.MAX_TIME_OUT || 2000;
 const EXPORT_TIME_OUT = process.env.EXPORT_TIME_OUT || 3600
 
-module.exports = {
+const config = {
   LIMIT_RECORDS,
   PORT,
   ALLOW_ORIGIN,
@@ -69,3 +69,5 @@ module.exports = {
   MAIL_PASSWORD,
   EXPORT_TIME_OUT,
 }
+
+module.exports = config

--- a/utils/email.js
+++ b/utils/email.js
@@ -5,6 +5,11 @@ const path = require('path');
 
 module.exports = {
     sendEmail: function (dst_email, subj, message, att){
+
+        if (!Globals.MAIL_ACCOUNT || !Globals.MAIL_HOST || !Globals.MAIL_PASSWORD || !Globals.MAIL_SERVICE) {
+            throw new Error('BulkAdd Email Service has not been configured');
+        }
+
         console.log(`${dst_email}, ${message}, ${Globals.MAIL_ACCOUNT}, ${Globals.MAIL_PASSWORD}`);
 
         let transporter = NodeMailer.createTransport(SmtpTransport({


### PR DESCRIPTION
## Summary

This PR makes some environment variables mandatory to start the server, removing defaults that could potentially be dangerous or lead hard to debug behavior.

## Changes
- Treat `ALLOW_ORIGIN` and `JWT_SECRET` variables as mandatory and remove their defaults.
- Treat `MAIL_*` related variables as optional, but include no defaults.
- If `MAIL_*` variables are not set, the `sendEmail` service will throw the appropriate error.

## Notes

- PR [graphql-server-model-codegen#183](https://github.com/Zendro-dev/graphql-server-model-codegen/pull/183) should be merged simultaneously. 