### PR TITLE
fix: array field import export

### DIFF
--- a/utils/file-tools.js
+++ b/utils/file-tools.js
@@ -222,7 +222,8 @@ exports.parseCsvStream = async function(csvFilePath, model, delim, cols, storage
     while (null !== (record = await csvStream.readAsync())) {
       record = exports.replacePojoNullValueWithLiteralNull(record);
       try {
-        let result = await validatorUtil.validateData('validateForCreate', model, record);
+        await validatorUtil.validateData('validateForCreate', model, record);
+        record = model.preWriteCast(record);
         if (storageType === "sql"){
           await model.create(record, {
             transaction: transaction

--- a/utils/simple-export.js
+++ b/utils/simple-export.js
@@ -20,10 +20,11 @@ crateHeaderCSV = function(attributes){
 jsonToCSV = function(row_data, attributes){
   let str_csv = "";
   attributes.forEach( att => {
-    if(row_data[att]===null || row_data[att] === undefined){
+    if(row_data[att]===null || row_data[att] === undefined || (Array.isArray(row_data[att]) && row_data[att].length === 0)){
       str_csv+='NULL,';
     }else {
-      str_csv+= row_data[att]+",";
+      str_csv += Array.isArray(row_data[att]) ? row_data[att].join(';') : row_data[att];
+      str_csv += ','
     }
   })
 


### PR DESCRIPTION
## Summary

This PR fixes data import and export for Array field type attributes

## Changes

- fix: add preWritecast to parseCsvstream after validating the record (row)
- fix: export arrayfields as a semicolon separated string
- fix: export empty array fields as NULL

