### PR TITLE
fix circular dependency warning

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -11,7 +11,11 @@ let models = {
   presto: {},
   neo4j: {},
 };
-const storageTypes = Object.keys(models).concat(["generic", "zendro-server", "distributed"]);
+const storageTypes = Object.keys(models).concat([
+  "generic",
+  "zendro-server",
+  "distributed",
+]);
 module.exports = models;
 
 // ****************************************************************************
@@ -21,30 +25,30 @@ module.exports = models;
  * Grabs all the models in your models folder, adds them to the models object
  */
 for (let storageType of storageTypes) {
-  if(existsSync(__dirname + "/" + storageType)) {
-
+  if (existsSync(__dirname + "/" + storageType)) {
     getModulesSync(__dirname + "/" + storageType).forEach((file) => {
       console.log("loaded model: " + file);
       let model = require(join(__dirname, storageType, file));
-      
+
       // used for setting up the storagehandler. generic, zendro-server and distributed types
       // don't have storage handlers assigned.
-      if(models[storageType])
+      if (Object.keys(models).includes(storageType)) {
         models[storageType][model.name] = model.definition;
-  
+      }
+
       let validator_patch = join("./validations", file);
       if (existsSync(validator_patch)) {
         model = require(`../${validator_patch}`).validator_patch(model);
       }
-  
+
       let patches_patch = join("./patches", file);
       if (existsSync(patches_patch)) {
         model = require(`../${patches_patch}`).logic_patch(model);
       }
-  
+
       if (model.name in models)
         throw Error(`Duplicated model name ${model.name}`);
-  
+
       models[model.name] = model;
     });
   }


### PR DESCRIPTION
Previously there was an warning about circular dependency from `models/index.js`. Because in `models` object there is no object for "**generic", "zendro-server", "distributed**". Hence, if we access them by `models[storageType]`, this kind of circular dependency would occur:
```
(node:152) Warning: Accessing non-existent property 'generic' of module exports inside circular dependency
(node:152) Warning: Accessing non-existent property 'distributed' of module exports inside circular dependency
```

And by this PR the issue has been addressed.