### PR TITLE
#99 PR fix: added shell-option for spawnSync

### DIFF
--- a/migrateDbAndStartServer.js
+++ b/migrateDbAndStartServer.js
@@ -13,12 +13,12 @@ runCheck(() => {
       'run',
       'dev'
       // ,'acl'
-    ], {stdio: "inherit"});
+    ], {stdio: "inherit", shell: process.platform === "win32"});
   else
     childProcess.spawnSync('npm', [
       'start'
       //,'acl'
-    ], {stdio: "inherit"});
+    ], {stdio: "inherit", shell: process.platform === "win32"});
 });
  
 /**


### PR DESCRIPTION
It seems that `spawnSync` for `npm` may not work in Windows if the `shell: true` option is not set.
This PR fixes this issue